### PR TITLE
merge-gatekeeper: treat cancelled runs the same way as skipped

### DIFF
--- a/internal/validators/status/validator.go
+++ b/internal/validators/status/validator.go
@@ -22,9 +22,10 @@ const (
 	checkRunCompletedStatus = "completed"
 )
 const (
-	checkRunNeutralConclusion = "neutral"
-	checkRunSuccessConclusion = "success"
-	checkRunSkipConclusion    = "skipped"
+	checkRunCancelledConclusion = "cancelled"
+	checkRunNeutralConclusion   = "neutral"
+	checkRunSuccessConclusion   = "success"
+	checkRunSkipConclusion      = "skipped"
 )
 
 const (
@@ -238,7 +239,7 @@ func (sv *statusValidator) listGhaStatuses(ctx context.Context) ([]*ghaStatus, e
 		switch *run.Conclusion {
 		case checkRunNeutralConclusion, checkRunSuccessConclusion:
 			ghaStatus.State = successState
-		case checkRunSkipConclusion:
+		case checkRunCancelledConclusion, checkRunSkipConclusion:
 			continue
 		default:
 			ghaStatus.State = errorState


### PR DESCRIPTION
Our team makes use of [Graphite](https://graphite.dev/) which in some cases will trigger GitHub workflows twice on the same commit, leading to race conditions and other undesirable behavior. I have a [PR open](https://github.com/clear-street-internal/fleet/pull/17925) to set concurrency flags on our workflows, so a second run on the same commit will cancel the first run. This is something that merge-gatekeeper doesn't handle properly, since it treats cancelled runs as failures and would block merging any PR where the concurrency flags triggered.

So I've written this patch to merge-gatekeeper that treats cancelled runs as "skipped" rather than "failure." It should not affect the behavior of a PR with manually cancelled runs, which still show up as failed in the GitHub merge UI, but it will make merge-gatekeeper treat an automatically cancelled run followed by a successful run as "success" rather than "failure."